### PR TITLE
performance

### DIFF
--- a/lib/dbox/database.rb
+++ b/lib/dbox/database.rb
@@ -368,8 +368,17 @@ module Dbox
       end
     end
 
-    def delete_all_entries
-      @db.execute('DELETE FROM entries;')
+    # When you push, you only want to delete entries in the subdirs
+    # you are pushing to. Otherwise you blow away all of the other
+    # entries in the DB, and the next sync will be really long.
+    def delete_all_entries(local_subdirs = nil)
+      if local_subdirs
+        local_subdirs.each do |subdir|
+          @db.execute("DELETE FROM entries where path_lower like '#{subdir}%'")
+        end
+      else
+        @db.execute('DELETE FROM entries;')
+      end
     end
 
     private

--- a/lib/dbox/syncer.rb
+++ b/lib/dbox/syncer.rb
@@ -410,7 +410,7 @@ module Dbox
         remote_contents = remote_contents.select { |c| in_subdir?(remote_to_relative_path(c.path_lower)) } if local_subdirs
 
         # Blow away the entries DB
-        database.delete_all_entries
+        database.delete_all_entries(local_subdirs)
 
         changelist = { created: [],
                        deleted: [],

--- a/spec/dbox_spec.rb
+++ b/spec/dbox_spec.rb
@@ -759,6 +759,35 @@ describe Dbox do
     end
   end
 
+  describe 'pushing with a subdir specified' do
+    it 'should not blow away the db for the other subdirs' do
+      Dbox.create(@remote, @local)
+      @alternate = "#{ALTERNATE_LOCAL_TEST_PATH}/#{@name}"
+      Dbox.clone(@remote, @alternate)
+
+      # Make some files and pull them from Dropbox
+      FileUtils.mkdir_p(File.join(@local, 'dir1/dir1a'))
+      FileUtils.mkdir_p(File.join(@local, 'dir2/dir2a'))
+      make_file "#{@local}/dir1/hello.txt"
+      make_file "#{@local}/dir1/dir1a/hello.txt"
+      make_file "#{@local}/dir2/goodbye.txt"
+      make_file "#{@local}/dir2/dir2a/goodbye.txt"
+      Dbox.push(@local)
+
+      # Make some local changes in dir1 and push them, with
+      # subdirs set to dir1
+      Dbox.pull(@alternate)
+      make_file "#{@alternate}/dir1/from_alternate.txt"
+      Dbox.push(@alternate, subdir: 'dir1')
+
+      # Pull
+      result = Dbox.pull(@alternate)
+      result.each do |key, arr|
+        arr.should be_empty
+      end
+    end
+  end
+
   describe 'multiple pushes and pulls' do
     it 'should not get out of sync' do
       Dbox.create(@remote, @local)


### PR DESCRIPTION
Fix a bug where we were blowing away the whole sqlite3 DB on every push.

Instead, we just blow away the DB entries for the directories we are pushing to. This keeps things in sync while still making the next pull reasonably fast.